### PR TITLE
在创建实例时设置一次字体

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ fn main() {
     eframe::run_native(
         "我的 egui 应用",
         options,
-        Box::new(|_cc| Box::new(People::default())),
+        Box::new(|cc| Box::new(People::new(cc))),
     );
 }
 
@@ -31,37 +31,18 @@ impl Default for People {
     }
 }
 
-//
+impl People {
+    fn new(cc: &eframe::CreationContext<'_>) -> Self {
+        setup_egui(&cc.egui_ctx);
+        Self::default()
+    }
+}
+
 impl eframe::App for People {
     // 每次 UI 需要重新绘制时调用
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
-
-        // 参考：https://github.com/emilk/egui/blob/0.17.0/eframe/examples/custom_font.rs
-
-        // 此内容存在 bug，即：运行时闪烁，会从乱码转换到不乱码的状态
-
-        // 从默认字体开始（我们将添加而不是替换它们）。
-        let mut fonts = egui::FontDefinitions::default();
-
-        // 安装我自己的字体（也许支持非拉丁字符）。
-        // 支持 .ttf 和 .otf 文件。
-        // STSONG.TTF 来自 Windows 10 系统的 C:\Windows\Fonts\STSONG.TTF
-        fonts.font_data.insert("my_font".to_owned(), egui::FontData::from_static(include_bytes!("STSONG.TTF")));
-
-        // 将我的字体放在首位（最高优先级）用于比例文本：
-        fonts.families.entry(egui::FontFamily::Proportional).or_default().insert(0, "my_font".to_owned());
-
-        // 将我的字体作为等宽字体的最后后备：
-        fonts.families.entry(egui::FontFamily::Monospace).or_default().push("my_font".to_owned());
-
-        // 告诉 egui 使用这些字体
-        // 新字体将在下一帧开始时激活。
-        // https://docs.rs/egui/latest/egui/struct.Context.html#method.set_fonts
-        ctx.set_fonts(fonts);
-
         // 中央面板
         egui::CentralPanel::default().show(ctx, |ui| {
-
             // 显示大文本
             ui.heading("我的 egui 应用程序");
 
@@ -85,4 +66,40 @@ impl eframe::App for People {
             ui.label(format!("你好 '{}', 年龄 {}", self.name, self.age));
         });
     }
+}
+
+fn setup_egui(ctx: &egui::Context) {
+    // 参考：https://github.com/emilk/egui/blob/0.17.0/eframe/examples/custom_font.rs
+
+    // 此内容存在 bug，即：运行时闪烁，会从乱码转换到不乱码的状态
+
+    // 从默认字体开始（我们将添加而不是替换它们）。
+    let mut fonts = egui::FontDefinitions::default();
+
+    // 安装我自己的字体（也许支持非拉丁字符）。
+    // 支持 .ttf 和 .otf 文件。
+    // STSONG.TTF 来自 Windows 10 系统的 C:\Windows\Fonts\STSONG.TTF
+    fonts.font_data.insert(
+        "my_font".to_owned(),
+        egui::FontData::from_static(include_bytes!("STSONG.TTF")),
+    );
+
+    // 将我的字体放在首位（最高优先级）用于比例文本：
+    fonts
+        .families
+        .entry(egui::FontFamily::Proportional)
+        .or_default()
+        .insert(0, "my_font".to_owned());
+
+    // 将我的字体作为等宽字体的最后后备：
+    fonts
+        .families
+        .entry(egui::FontFamily::Monospace)
+        .or_default()
+        .push("my_font".to_owned());
+
+    // 告诉 egui 使用这些字体
+    // 新字体将在下一帧开始时激活。
+    // https://docs.rs/egui/latest/egui/struct.Context.html#method.set_fonts
+    ctx.set_fonts(fonts);
 }


### PR DESCRIPTION
删除在每一次更新时设置字体的代码。

原来那个 discussion 里的旧 API 已经取消了，我重新看了下示例。